### PR TITLE
Remove 0-value liabilities from generated dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For convience we number liabilities based on the prevailing bitcoin block height
 
     sub_nonce = sha256(account_nonce || block_height || account_number)
 
-Next all user balances are split ("blinded") into multiple parts, with the ratio of the split determined by a random number generator, thereby information about the distribution of account balances, and active users over time on the participating platform is no longer revealed. The parts are shuffled into a random order.
+Next all user balances are split ("blinded") into multiple parts, with the ratio of the split determined by a random number generator, thereby information about the distribution of account balances, and active users over time on the participating platform is no longer revealed. 0-value liabilities are dropped as they are not liabilities at all. The parts are shuffled into a random order.
 
 Next the liability chunks are arranged as the leaves of a merkle sum proof, a modified version of the [Maxwell Proof of Liabilities](https://bitcointalk.org/index.php?topic=595180.0) scheme.
 
@@ -122,21 +122,21 @@ Continuing our sample dataset:
 
     % python3 generate_liabilities.py --liabilities liabilities-100-20210225D150000099012000.csv --blockheight 100 | tee liabilities-100-proof.csv
     block_height:100
-    85b0a83970a74a6ad0ee5d4bec5d3afe0048d18b8342e31e2d3a45e0f17879c7,4000004000
-    4e6661db50e4ec1c42204c471c0a6fa2a8749127368f3358c340752208b160c9,963611993
-    128b3b2bd3f6bde35d5ac2ba0a37def53fad7a607e6cdd76ee4ad39472b44447,3036392007
-    448e972f7919df255c250b61d6ae1ea165f94cae229f3f610359ae0e2e63acb9,963610699
-    bfa7eddb8a0a00f8e1eda939c41eaba51f9555b32d45b6f5828bca3950eea31f,1294
-    51fb2bcf79c0439694c391960cfc0838db369b6fb2687c1fd4636476a2c34ca7,2039
-    9649f6034051c9c81e3d246ae90473da35a8c02b4321c1b61436b75da139cf53,3036389968
-    69c492be8d5b1f3cc507047460cabc116495e03fa6c76a7767655a94c2b9ae4f,963610032
-    acb9b9fb9ae63ae09927dac870fa203d0113dade58f20a9855193b121d3ed035,667
-    cbcdfae2f947e2b5b7dc2268f0f02f230867b77a0742940af16eff46f457a10e,0
-    003c7fc49a6a476894dd6edfca066d5e3fe01cc63906214134fb6e2ee06a7d83,1294
-    4c28a5dda0bb0dc42af1d942ea12b1f5fe1e3a22049de33166262c724363df63,333
-    2150701b63061ebffa09aa4a0fb239fd59143e6f7ba7cdec3714412d09b97db3,1706
-    f7c28544e2beb1abe170ca4d1aa177236f8e43383c2e83420bcbe8375aa4ba9b,1543636957
-    943f858e804d09d241b05c9d063030da551ca4bde5133b303c8f23a4b76a5fde,1492753011
+    ceb08dfd693430ece544df853a989684056c0800088d61bfcc38c0d16cc1e1c7,4000004000
+    449b24ad1789df614e1de58a924a312335cf2bb8d9830c89b113d74354bcea78,2352507629
+    6ad03b1284e87e672cb57fcf3d97e64ef1eff6c648679c33e433d4b2b0636c33,1647496371
+    e54b0f6e0ec5845eed44f1b9e58d202ac8468b3fcb0c2d4961846d1d6cdff7b1,1076759806
+    b9bee9ed5991578f3674622172d4d14397e7eff8eb8fc19cb20c9421dab17c84,1275747823
+    dbe039f6addaf13a7a712d34a946f0ffb1106884a2ca978bc8c34ea4fb262938,1647493311
+    9640e3293a500a40638c22b51ddebc9b6046b9d9bda17b832debee81d57e9fb6,3060
+    48e433bb032ad89fc9ff52ab74c0a6af295fe41be6a1300fe8b02febbce535fc,450471613
+    bcb09e9ed1450e39e1b5ebb44c299d9d40408026f388fd8b57117dacf8b5f335,626288193
+    8701c3bc3bbc1e6e7699129f812ea915eff8fb4bb4d644189580a887d24741c5,530
+    b7cae0de2ac83de99b0e02f19d2b420dd07ad3e93e0b360119b4c98b63e98b02,1275747293
+    e078517622f1f679851e1d5e61a9d3f44589e5c750b541714154ea028f12e6f7,1647492901
+    b3ca4573d1c7b56c4834bff4f11804ec82a39fa47de3c45cccfee2ef49c1d05e,410
+    31e1e8af2893f647a4c933454b99170799f5591895814eb52e208280cef132eb,590
+    20f222b2a4e1ebc3ba36e2907095604cf982a919d9b16ac2083d9881131e02d5,2470
 
     $ cat nonces.txt
     2,b88860add96111d84d38a500266df715158f91375d9aaa98aa58356f9a872412

--- a/generate_liabilities.py
+++ b/generate_liabilities.py
@@ -95,6 +95,9 @@ def generate_liabilities_tree(liabilities, user_nonces, block_height, min_split=
                 val2 = liability[1]-val1
                 stretched_liabilities.append([liability[0], val1])
                 stretched_liabilities.append([liability[0], val2])
+            elif liability[1] == 0:
+                # 0-value liabilities are no liabilities at all
+                continue
             else:
                 stretched_liabilities.append(liability)
 

--- a/generate_liabilities.py
+++ b/generate_liabilities.py
@@ -71,7 +71,10 @@ def parse_liabilities(liabilities_text):
         liabilities.append([int(liability[0]), int(liability[1])])
     return liabilities
 
-def generate_liabilities_tree(liabilities, user_nonces, block_height, min_split=2):
+
+def generate_liabilities_tree(
+    liabilities, user_nonces, block_height, min_split=2, exclude_zeros=True
+):
 
     # Find the next power of two leaf size that gives reasonable amount of value anonomity
     # We want every leaf to be split at least once!
@@ -91,12 +94,14 @@ def generate_liabilities_tree(liabilities, user_nonces, block_height, min_split=
             # If leaf is value 1, it cannot be meaningfully split
             if stretched_liabilities_len < final_leaf_number and liability[1] > 1:
                 stretched_liabilities_len += 1
-                val1 = random.SystemRandom().randint(1,liability[1]-1) # Split should always leave at least 1 sat on both leaves
-                val2 = liability[1]-val1
+                # Split should always leave at least 1 sat on both leaves
+                val1 = random.SystemRandom().randint(1, liability[1] - 1)
+                val2 = liability[1] - val1
                 stretched_liabilities.append([liability[0], val1])
                 stretched_liabilities.append([liability[0], val2])
-            elif liability[1] == 0:
-                # 0-value liabilities are no liabilities at all
+            elif liability[1] == 0 and exclude_zeros:
+                # 0-value liabilities can be filtered out and dealt with by not matching
+                # any leaves
                 continue
             else:
                 stretched_liabilities.append(liability)

--- a/test/test_liabilities.py
+++ b/test/test_liabilities.py
@@ -7,36 +7,46 @@ import subprocess
 import unittest
 from validate_liabilities import gen_sub_nonce
 
+
 class TestLiabilities(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         logging.getLogger().setLevel(logging.INFO)
-
 
     @classmethod
     def tearDownClass(self):
         print("Tearing down unit tests...", flush=True)
 
     def test_liabilities(self):
-        logging.info("Generating a regtest PoL file, and running it through the validator")
+        logging.info("Generating test liabilities")
 
         # Generate a list of 7 account-sat_balance pairs
-        account_list = [(5,1)]
-        account_map = {5:1}
+        account_list = [(5, 1), (3, 0)]
         for i in range(6):
             # We don't expect account collision here in test, all values are serialized as 64-bit uints
-            account_list.append((random.randrange(2**64), random.randrange((2**64)/8)))
-            account_map[account_list[-1][0]] = account_list[-1][1]
+            # divide by 8 is to avoid overflow at the root liability
+            account_list.append(
+                (random.randrange(2 ** 64), random.randrange((2 ** 64) / 8))
+            )
 
+        account_map = dict(account_list)
         with open("balances.txt", "w") as f:
             f.write("account,amount\n")
             for account in account_list:
                 f.write("{},{}\n".format(account[0], account[1]))
 
         # Put through PoL proof generator
-        block_height = str(random.randrange(2**64)) # Just has to be 8 byte number and unique per real proof for privacy
-        run_args = ["python3", "/app/generate_liabilities.py", "--liabilities", "balances.txt", "--blockheight", block_height]
-        output = subprocess.check_output(run_args).decode('utf-8')
+        # any 8 byte number, unique per real proof for privacy
+        block_height = str(random.randrange(2 ** 64))
+        run_args = [
+            "python3",
+            "/app/generate_liabilities.py",
+            "--liabilities",
+            "balances.txt",
+            "--blockheight",
+            block_height,
+        ]
+        output = subprocess.check_output(run_args).decode("utf-8")
         with open("liability_proof.txt", "w") as f:
             f.write(output)
 
@@ -45,8 +55,8 @@ class TestLiabilities(unittest.TestCase):
         # Make sure output file has split into 16 leaves, none of them value 0
 
         # 16 leaves, 15 nodes, 1 blockheight output, and one empty line
-        self.assertEqual(len(output), 16+15+1+1)
-        self.assertEqual(output[0], "block_height:"+block_height)
+        self.assertEqual(len(output), 16 + 15 + 1 + 1)
+        self.assertEqual(output[0], "block_height:" + block_height)
         for line in output[1:]:
             if line == "":
                 break
@@ -59,12 +69,26 @@ class TestLiabilities(unittest.TestCase):
                     account, nonce = line.split(",")
                     # Making sub-nonce which is served by the API to users by default
                     if nonce_arg == "--nonce":
-                        nonce = gen_sub_nonce(nonce , int(block_height), int(account)).hex()
+                        nonce = gen_sub_nonce(
+                            nonce, int(block_height), int(account)
+                        ).hex()
                     # Call validator tool
-                    run_args = ["python3.7", "/app/validate_liabilities.py", "--account", account, nonce_arg, nonce.strip(), "--proof", "liability_proof.txt"]
-                    output = subprocess.check_output(run_args).decode('utf-8')
-                    validated_amount = int(re.findall("Validated (\d+)", output.replace(",", ""))[0])
+                    run_args = [
+                        "python3.7",
+                        "/app/validate_liabilities.py",
+                        "--account",
+                        account,
+                        nonce_arg,
+                        nonce.strip(),
+                        "--proof",
+                        "liability_proof.txt",
+                    ]
+                    output = subprocess.check_output(run_args).decode("utf-8")
+                    validated_amount = int(
+                        re.findall("Validated (\d+) sats", output.replace(",", ""))[0]
+                    )
                     self.assertEqual(account_map[int(account)], validated_amount)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
They actually leak information that a user has an empty account, and are otherwise useless.

A user with 0 value in their account will end up with the right value printed at the end anyways.