### PR TITLE
support multiple pubkeys in reserves file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+__pycache__
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM ubuntu:18.04 as builder
-RUN apt-get update && apt-get install -y software-properties-common
+FROM ubuntu:20.04 as builder
 RUN export DEBIAN_FRONTEND=noninteractive; export TZ=America/New_York; \
-    apt-get update && apt-get install python3.7 python3-pip\
+    apt-get update && apt-get install python3.9 python3-pip python-is-python3\
     curl git-all wget python-apt -y
 
 RUN mkdir /app
@@ -14,9 +13,9 @@ COPY requirements.txt requirements.dev.txt /app/
 RUN pip3 install -r /app/requirements.txt -r /app/requirements.dev.txt
 COPY validate_reserves.py /app/validate_reserves.py
 COPY test/test_reserves.py /app/test_reserves.py
-RUN python3 /app/test_reserves.py
+RUN python /app/test_reserves.py
 COPY generate_liabilities.py /app/generate_liabilities.py
 COPY validate_liabilities.py /app/validate_liabilities.py
 COPY test/test_liabilities.py /app/test_liabilities.py
-RUN python3.7 /app/test_liabilities.py
+RUN python /app/test_liabilities.py
 RUN black --check /app/*.py

--- a/test/test_liabilities.py
+++ b/test/test_liabilities.py
@@ -39,7 +39,7 @@ class TestLiabilities(unittest.TestCase):
         # any 8 byte number, unique per real proof for privacy
         block_height = str(random.randrange(2**64))
         run_args = [
-            "python3",
+            "python",
             "/app/generate_liabilities.py",
             "--liabilities",
             "balances.txt",
@@ -74,7 +74,7 @@ class TestLiabilities(unittest.TestCase):
                         ).hex()
                     # Call validator tool
                     run_args = [
-                        "python3.7",
+                        "python",
                         "/app/validate_liabilities.py",
                         "--account",
                         account,

--- a/test/test_reserves.py
+++ b/test/test_reserves.py
@@ -212,7 +212,7 @@ class TestReserves(unittest.TestCase):
 
         # Run validator tool against the proof file
         run_args = [
-            "python3",
+            "python",
             "/app/validate_reserves.py",
             "--rpcauth",
             "user:password",
@@ -237,7 +237,7 @@ class TestReserves(unittest.TestCase):
 
         # --reconsider call to make sure that it resets blockheight of the node, don't use rpchost to check default
         run_args = [
-            "python3",
+            "python",
             "/app/validate_reserves.py",
             "--rpcauth",
             "user:password",
@@ -259,7 +259,7 @@ class TestReserves(unittest.TestCase):
 
         # Run validator tool against the proof file
         run_args = [
-            "python3",
+            "python",
             "/app/validate_reserves.py",
             "--rpcauth",
             "user:password",

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -226,8 +226,16 @@ def compile_proofs(rpc, proof):
 
             elif addr_info["addr_type"] in ("wpkh"):
                 # check xpub, then we present descriptor as script
-                assert xpubs[0] in addr_info["script"]
-                descriptor = addr_info["script"]
+                for xp in xpubs:
+                    if xp in addr_info["script"]:
+                        descriptor = addr_info["script"]
+                        break
+                else:
+                    raise Exception(
+                        "None of expected pubkeys found in descriptor {}".format(
+                            addr_info["script"]
+                        )
+                    )
             else:
                 raise Exception(
                     "Unknown address type {}".format(addr_info["addr_type"])


### PR DESCRIPTION
Allow reserves claims to include addresses derived from multiple pubkeys.
Upgrade base ubuntu image, since upgraded `requests` dependency requires python >3.7. Use `python-is-python3` package to simplify interpreter choice. 

@k4r1  can you review, and edit the settings of this project to require CI pass before allowing merge?