### PR TITLE
standard arg --bitcoin, validate_reserves.py exits nonzero on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ succeeding eventually.
 
 Sample output from running PoR tool on testnet dataset against testnet bitcoind RPC server.
 ```
-$ python3 validate_reserves.py --proof testnet_reserves.yaml --rpcauth username:password 127.0.0.1 --rpcport 18332
+$ python3 validate_reserves.py --proof testnet_reserves.yaml --bitcoind testnet://username:password@localhost:18332
 ...
 WARNING:root:Proof of Reserves on pruned nodes not well-supported. Node can get stuck reorging past pruned blocks.
 INFO:root:Bitcoind alive: At block 1938810
@@ -69,7 +69,7 @@ Proven amount(BTC): 205393.049391
 INFO:root:IMPORTANT! Call this script with --reconsider to bring your bitcoin node back to tip when satisfied with the results
 
 # Run --reconsider to re-set your node to undo block invalidations, getting your node back to chaintip
-$ python3 validate_reserves.py --reconsider --rpcauth username:password --rpcport 18332
+$ python3 validate_reserves.py --reconsider --bitcoind testnet://username:password@localhost:18332
 INFO:root:Reconsidering blocks and exiting.
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ succeeding eventually.
 
 Sample output from running PoR tool on testnet dataset against testnet bitcoind RPC server.
 ```
-$ python3 validate_reserves.py --proof testnet_reserves.yaml --bitcoind testnet://username:password@localhost:18332
+$ python3 validate_reserves.py --proof testnet_reserves.yaml --bitcoin testnet://username:password@localhost:18332
 ...
 WARNING:root:Proof of Reserves on pruned nodes not well-supported. Node can get stuck reorging past pruned blocks.
 INFO:root:Bitcoind alive: At block 1938810
@@ -69,7 +69,7 @@ Proven amount(BTC): 205393.049391
 INFO:root:IMPORTANT! Call this script with --reconsider to bring your bitcoin node back to tip when satisfied with the results
 
 # Run --reconsider to re-set your node to undo block invalidations, getting your node back to chaintip
-$ python3 validate_reserves.py --reconsider --bitcoind testnet://username:password@localhost:18332
+$ python3 validate_reserves.py --reconsider --bitcoin testnet://username:password@localhost:18332
 INFO:root:Reconsidering blocks and exiting.
 ```
 

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -335,10 +335,10 @@ def validate_proofs(bitcoin, proof_data):
                 )
             )
 
-        proven_amount += res["total_amount"]
+        proven_amount += int(100000000 * res["total_amount"])
 
     logging.info(
-        "***RESULTS***\nHeight of proof: {}\nBlock proven against: {}\nClaimed amount (BTC): {}\nProven amount(BTC): {}".format(
+        "***RESULTS***\nHeight of proof: {}\nBlock proven against: {}\nClaimed amount (sats): {}\nProven amount(sats): {}".format(
             proof_data["height"], block_hash, proof_data["total"], proven_amount
         )
     )
@@ -414,6 +414,6 @@ if __name__ == "__main__":
 
         if validated["amount_claimed"] > validated["amount_proven"]:
             print(
-                "WARNING: More claimed {validated['amount_claimed']} than proven {validated['amount_proven']}"
+                f"WARNING: More claimed {validated['amount_claimed']} than proven {validated['amount_proven']}"
             )
             exit(-1)

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -51,7 +51,7 @@ class BitcoinRPC:
                 self.version = self.getnetworkinfo([])["version"]
                 break
             except Exception as e:
-                logging.info("Bitcoin server not responding, sleeping for retry.")
+                logging.exception("Bitcoin server not responding, sleeping for retry.")
 
 
 def read_proof_file(proof_file):
@@ -337,12 +337,9 @@ def validate_proofs(bitcoin, proof_data):
 
         proven_amount += res["total_amount"]
 
-        if args.verbose:
-            logging.info(res)
-
     logging.info(
-        "***RESULTS***\nHeight of proof: {}\nBlock proven against: {}\nProven amount(BTC): {}".format(
-            proof_data["height"], block_hash, proven_amount
+        "***RESULTS***\nHeight of proof: {}\nBlock proven against: {}\nClaimed amount (BTC): {}\nProven amount(BTC): {}".format(
+            proof_data["height"], block_hash, proof_data["total"], proven_amount
         )
     )
     return {
@@ -380,7 +377,7 @@ if __name__ == "__main__":
         action="store_true",
     )
     parser.add_argument(
-        "--bitcoind", default=BITCOIND_DEFAULT, help="Override bitcoind URI"
+        "--bitcoin", default=BITCOIND_DEFAULT, help="Override bitcoind URI"
     )
     parser.add_argument(
         "--verbose", "-v", help="Prints more information about scanning results"
@@ -391,7 +388,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    bitcoin = BitcoinRPC(args.bitcoind)
+    bitcoin = BitcoinRPC(args.bitcoin)
     logging.getLogger().setLevel(logging.INFO)
 
     bitcoin.wait_until_alive()


### PR DESCRIPTION
* allow setting network, rpc credentials and host/port as a URI 
* use our standard bitcoin rpc class
* make `validate_reserves.py` exit with non-zero return code for invalid claims
* remove side-effects and RPC from `compile_proofs`
* support a set of pubkeys larger than `n`, provided that that `m-of-n` is drawn from that set (allows key rotation)

Motivation is to more easily allow `validate_reserves.py` to be scripted, by including it as an import.
These changes allow our *testnet* reserves files to validate.  