### PR TITLE
allow override of validate_proofs chunksize, fix float sats parsing, fix rewinds 

### DIFF
--- a/test/test_reserves.py
+++ b/test/test_reserves.py
@@ -90,6 +90,7 @@ def make_reserves_proof(bitcoin, dep_sizes=["0.0001", "0.00004", "0.000007"]):
     )
 
     dep_sizes = [Decimal(x) for x in dep_sizes]
+    dep_sats = [int(100000000 * dep) for dep in dep_sizes]
 
     # Deposit some specific amounts for testing the utxo scanning
     gen_addr = bitcoin.getnewaddress([])
@@ -122,7 +123,7 @@ def make_reserves_proof(bitcoin, dep_sizes=["0.0001", "0.00004", "0.000007"]):
         "height": proof_height,
         "chain": "regtest",
         "claim": {"m": 3, "n": 4},
-        "total": int(100000000 * sum(dep_sizes)),
+        "total": sum(dep_sats),
         "keys": static_uncompressed_keys,
     }
     proof["address"] = [
@@ -130,16 +131,19 @@ def make_reserves_proof(bitcoin, dep_sizes=["0.0001", "0.00004", "0.000007"]):
             "addr_type": "sh",
             "addr": legacy["address"],
             "script": legacy["redeemScript"],
+            "balance": dep_sats[0],
         },
         {
             "addr_type": "sh_wsh",
             "addr": nested["address"],
             "script": nested["redeemScript"],
+            "balance": dep_sats[1],
         },
         {
             "addr_type": "wsh",
             "addr": native["address"],
             "script": native["redeemScript"],
+            "balance": dep_sats[2],
         },
     ]
     return proof

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -3,6 +3,7 @@
 import argparse
 import copy
 from collections import Counter
+import decimal
 import json
 import logging
 import math
@@ -37,7 +38,7 @@ class BitcoinRPC:
             r = requests.post(self.bitcoind, json=data, **kwargs)
             logging.debug(r.text)
             r.raise_for_status()
-            result = r.json()
+            result = r.json(parse_float=decimal.Decimal)
             if result["error"] is not None:
                 raise JsonRPCException(result["error"])
             return result["result"]

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -198,7 +198,7 @@ def compile_proofs(proof_data):
     }
 
 
-def validate_proofs(bitcoin, proof_data):
+def validate_proofs(bitcoin, proof_data, chunk_size=60000):
     if proof_data is None:
         raise Exception("Needs proof arg")
 
@@ -282,7 +282,6 @@ def validate_proofs(bitcoin, proof_data):
         best_hash = bitcoin.getbestblockhash([], timeout=30)
 
     # "413 Request Entity Too Large" otherwise
-    chunk_size = 60000
     num_scan_chunks = math.ceil(len(descriptors_to_check) / chunk_size)
     proven_amount = 0
     for i in range(num_scan_chunks):

--- a/validate_reserves.py
+++ b/validate_reserves.py
@@ -244,7 +244,7 @@ def validate_proofs(bitcoin, proof_data, chunk_size=60000):
             raise Exception("Fatal: Unable to retrieve block at snapshot height")
 
     logging.info(
-        f"Running against {proof_data['chain']} chain, rewinding tip to {block_hash}".format()
+        f"Running against {proof_data['chain']} chain, rewinding tip to {block_hash}"
     )
 
     # there could be forks leading from the block we want, so we need to invalidate them


### PR DESCRIPTION
Fix a bug with rewinding to the height of a legitimate fork, which potentially causes a hang
Check reserves input 'balance' values sum up correctly   
Bitcoind memory use scales with chunksize, allow it to be overridden from cli.
Fix an observed issue with float rounding during JSON parsing of amounts returned from `scantxoutset`.
